### PR TITLE
Reduce documentation to one level

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,42 +8,15 @@ Where , multiple Infrastructure resource types can be defined with a single topo
 |-- bin # binaries needed 
 |-- docs # documentation 
 |-- ex_schemas # example Schema definitions
-|   `-- os_server_roles.json
 |-- ex_topo # example topologies
-|   |-- ex_data_os_server.yml
 |-- group_vars # variables applicable for groups
-|   `-- all
 |-- hosts # inventory hosts file
 |-- inventory # dynamic inventory scripts
 |-- library # custom modules library
-|   `-- schema_check
-|       `-- schema_check.py
 |-- plugins # custom plugins
 |-- README.md
 |-- roles # roles handling resource specific provisioning
-|   |-- aws
-|   |   |-- handlers
-|   |   |   `-- main.yml
-|   |   |-- tasks
-|   |   |   `-- main.yml
-|   |   `-- templates
-|   |-- common 
-|   |   |-- handlers
-|   |   |   `-- main.yml
-|   |   |-- tasks
-|   |   |   `-- main.yml
-|   |   `-- templates
-|   `-- openstack
-|       |-- handlers
-|       |   `-- main.yml
-|       |-- tasks
-|       |   |-- main.yml
-|       |   `-- provision_resource_group.yml 
-|       |   `-- provision_res_defs.yml
-|       |-- templates
-|       `-- vars #contains openstack credential files
-|           |-- examplecreds.yml
-|-- site.yml
+|-- site.yml # top level Ansible playbook
 `-- tests # tests cases
 ```
 

--- a/docs/source/intro_getting_started.rst
+++ b/docs/source/intro_getting_started.rst
@@ -18,85 +18,14 @@ The current directory structure of linchpin should look lika as follows::
     
     .
     ├── docs
-    │   ├── make.bat
-    │   ├── Makefile
-    │   └── source
-    │       ├── conf.py
-    │       ├── index.rst
-    │       ├── installation.rst
-    │       ├── intro_getting_started.rst
-    │       ├── intro_installation.rst
-    │       ├── intro.rst
-    │       └── license.rst
     ├── ex_schemas
-    │   ├── os_server_roles.json
-    │   └── schema_v2.json
     ├── ex_topo
-    │   └── ex_data.yml
     ├── group_vars
-    │   └── all
     ├── hosts
     ├── library
-    │   ├── output_parser
-    │   │   └── output_parser.py
-    │   └── schema_check
-    │       └── schema_check.py
     ├── README.md
     ├── requirements.txt
     ├── roles
-    │   ├── aws
-    │   │   ├── handlers
-    │   │   │   └── main.yml
-    │   │   ├── tasks
-    │   │   │   ├── deprovision_res_defs.yml
-    │   │   │   ├── deprovision_resource_group.yml
-    │   │   │   ├── main.yml
-    │   │   │   ├── provision_res_defs.yml
-    │   │   │   └── provision_resource_group.yml
-    │   │   ├── templates
-    │   │   │   └── output_formatter.j2
-    │   │   └── vars
-    │   │       └── ex_aws_creds.yml
-    │   ├── common
-    │   │   ├── handlers
-    │   │   │   └── main.yml
-    │   │   └── tasks
-    │   │       └── main.yml
-    │   ├── duffy
-    │   │   ├── tasks
-    │   │   │   ├── main.yml
-    │   │   │   ├── provision_res_defs.yml
-    │   │   │   ├── provision_resource_group.yml
-    │   │   │   ├── teardown_res_defs.yml
-    │   │   │   └── teardown_resource_group.yml
-    │   │   └── vars
-    │   │       └── ex_duffy_creds.yml
-    │   ├── gcloud
-    │   │   ├── handlers
-    │   │   │   └── main.yml
-    │   │   ├── tasks
-    │   │   │   ├── main.yml
-    │   │   │   ├── provision_res_defs.yml
-    │   │   │   └── provision_resource_group.yml
-    │   │   └── vars
-    │   │       └── ex_gcloud_creds.yml
-    │   ├── openstack
-    │   │   ├── handlers
-    │   │   │   └── main.yml
-    │   │   ├── tasks
-    │   │   │   ├── main.yml
-    │   │   │   ├── provision_os_server.yml
-    │   │   │   ├── provision_res_defs.yml
-    │   │   │   └── provision_resource_group.yml
-    │   │   └── vars
-    │   │       └── ex_os_creds.yml
-    │   └── output_writer
-    │       ├── handlers
-    │       │   └── main.yml
-    │       ├── tasks
-    │       │   └── main.yml
-    │       └── templates
-    │           └── output_formatter.j2
     └── site.yml
 
 .. _understanding_directory_structure:


### PR DESCRIPTION
Documenting more than one level of folders is unnecessary for
the top level docs overview. All that does is introduce more
places where manual changes need to be made to keep the tree
in sync with the documented trees (and these two trees were
both already out of sync with the actual project tree). Reducing
it to one level of directory makes this easier to maintain,
as the top level structure of the project should change much
less frequently than the internals.