### PR TITLE
added missing conditional in keypair provisioning and cleaned unnecessary vars

### DIFF
--- a/provision/roles/openstack/tasks/provision_os_keypair.yml
+++ b/provision/roles/openstack/tasks/provision_os_keypair.yml
@@ -42,10 +42,7 @@
   register: job_result
   until: job_result.finished
   retries: 30
-
-- name: "debug on keypair "
-  debug:
-    msg: "{{ job_result }}"
+  when: async == true
 
 - name: "Async:: Generate keyfile "
   copy:

--- a/provision/site.yml
+++ b/provision/site.yml
@@ -8,20 +8,13 @@
 - name:  "Provisioning resources based on resource group type"
   hosts: localhost 
   roles:
-    - { role: 'openstack', os_res_grps: "{{ os_res_grps }}" }
-    - { role: 'aws', aws_res_grps: "{{ aws_res_grps  }}" }
-    - { role: 'gcloud', gce_res_grps: "{{ gcloud_res_grps }}" }
-    - { role: 'duffy', duffy_res_grps: "{{ duffy_res_grps }}" }
-    - { role: 'libvirt', libvirt_res_grps: "{{ libvirt_res_grps }}" }
+    - { role: 'openstack'}
+    - { role: 'aws' }
+    - { role: 'gcloud' }
+    - { role: 'duffy' }
+    - { role: 'libvirt'}
 
 - name: "Writing contents to file"
   hosts: localhost
   roles:
     - { role: 'output_writer', topology_outputs: "{{ topology_outputs }}" }
-
-- name: "debug statement"
-  hosts: localhost
-  tasks:
-    - name: "debug the job ids"
-      debug:
-        msg: "{{ topology_job_ids }}"


### PR DESCRIPTION
Added missing conditional for keypair provisioning. 
removed  *_grp_vars , As we can access the *_grp_vars inside the roles , we need not pass them as parameters to the roles again . (which might create a recursive loop.)