### PR TITLE
Add more default paths to look for linchpin_config

### DIFF
--- a/linchpin_api/v1/api.py
+++ b/linchpin_api/v1/api.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import inspect
 import ansible
 import pprint
@@ -23,8 +24,7 @@ from github import GitHub
 class LinchpinAPI:
 
     def __init__(self):
-        base_path = os.path.dirname(__file__).split("/")
-        base_path = base_path[0:-2]
+        base_path = os.path.dirname(__file__).split("/")[0:-2]
         self.base_path = "/".join(base_path)
         self.excludes = set(["topology_upstream",
                              "layout_upstream",
@@ -38,8 +38,8 @@ class LinchpinAPI:
                             cwd+"/linch-pin/linchpin_config.yml", #for jenkins
                             "~/.linchpin_config.yml",
                             self.base_path+"/linchpin_config.yml",
-                            "/usr/linchpin_config.yml",
                             "/etc/linchpin_config.yml"]
+            config_files.extend(sys.path)
             for c_file in config_files:
                 print("debug:: searching linchpin_config file from path :: ")
                 print(c_file)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def list_all_files(root_dir):
 
 setup(
     name='linchpin',
-    version='0.8.5',
+    version='0.8.6',
     description = 'Ansible based multi cloud orchestrator',
     author = 'samvaran kashyap rallabandi',
     author_email = 'samvaran.kashyap@gmail.com',


### PR DESCRIPTION
If, for some reason, we can't find the linchpin_config.yml in the initial paths, use the default one in the package. It should be somewhere in the sys.path.