### PR TITLE
Completed Libvirt plugin

### DIFF
--- a/InventoryFilters/GenericInventory.py
+++ b/InventoryFilters/GenericInventory.py
@@ -13,6 +13,7 @@ from AWSInventory import AWSInventory
 from OpenstackInventory import OpenstackInventory
 from GCloudInventory import GCloudInventory
 from DuffyInventory import DuffyInventory
+from LibvirtInventory import LibvirtInventory
 from InventoryFilter import InventoryFilter
 from InventoryProviders import get_driver, get_all_drivers
 

--- a/InventoryFilters/InventoryProviders.py
+++ b/InventoryFilters/InventoryProviders.py
@@ -7,6 +7,7 @@ from OpenstackInventory import OpenstackInventory
 from GCloudInventory import GCloudInventory
 from DuffyInventory import DuffyInventory
 from BeakerInventory import BeakerInventory
+from LibvirtInventory import LibvirtInventory
 from InventoryFilter import InventoryFilter
 
 filter_classes = {
@@ -14,7 +15,8 @@ filter_classes = {
            "os_inv": OpenstackInventory,
            "gcloud_inv": GCloudInventory,
            "duffy_inv": DuffyInventory,
-           "beaker_inv": BeakerInventory
+           "beaker_inv": BeakerInventory,
+           "libvirt_inv": LibvirtInventory
 }
 
 

--- a/InventoryFilters/LibvirtInventory.py
+++ b/InventoryFilters/LibvirtInventory.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import abc
+import StringIO
+from ansible import errors
+
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
+
+from InventoryFilter import InventoryFilter
+
+
+class LibvirtInventory(InventoryFilter):
+
+    def get_host_ips(self, topo):
+        ips = []
+        for val in topo['libvirt_res']:
+            print('ip: {}'.format(val))
+            ips.append(val)
+        return ips
+
+    def get_inventory(self, topo, layout):
+        if len(topo['duffy_res']) == 0:
+            return ""
+        inventory = ConfigParser(allow_no_value=True)
+        layout_hosts = self.get_layout_hosts(layout)
+        inven_hosts = self.get_host_ips(topo)
+        # adding sections to respective host groups
+        host_groups = self.get_layout_host_groups(layout)
+        self.add_sections(host_groups)
+        # set children for each host group
+        self.set_children(layout)
+        # set vars for each host group
+        self.set_vars(layout)
+        # add ip addresses to each host
+        self.add_ips_to_groups(inven_hosts, layout)
+        self.add_common_vars(host_groups, layout)
+        output = StringIO.StringIO()
+        self.config.write(output)
+        return output.getvalue()

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -87,12 +87,13 @@ class LinchpinCli(LinchpinAPI):
                 if e_vars['topology'] is None:
                     print("Topology not found !!")
                     break
-                layout_path = self.find_layout(pf[key]["layout"], pf)
-                e_vars['inventory_layout_file'] = layout_path
-                if e_vars['inventory_layout_file'] is None:
-                    print("Layout not found !!")
-                    break
-                print(e_vars)
+                if pf[key].has_key('layout'):
+                    layout_path = self.find_layout(pf[key]["layout"], pf)
+                    e_vars['inventory_layout_file'] = layout_path
+                    if e_vars['inventory_layout_file'] is None:
+                        print("Layout not found !!")
+                        break
+                    print(e_vars)
                 output = invoke_linchpin(self.base_path,
                                          e_vars,
                                          "PROVISION",
@@ -104,11 +105,12 @@ class LinchpinCli(LinchpinAPI):
                 e_vars['topology'] = topology_path
                 if e_vars['topology'] is None:
                     print("Topology not found !!")
-                layout_path = self.find_layout(pf[target]["layout"], pf)
-                e_vars['inventory_layout_file'] = layout_path
-                if e_vars['inventory_layout_file'] is None:
-                    print("Layout not found !!")
-                print(e_vars)
+                if pf[key].has_key('layout'):
+                    layout_path = self.find_layout(pf[target]["layout"], pf)
+                    e_vars['inventory_layout_file'] = layout_path
+                    if e_vars['inventory_layout_file'] is None:
+                        print("Layout not found !!")
+                    print(e_vars)
                 output = invoke_linchpin(self.base_path,
                                          e_vars,
                                          "PROVISION",

--- a/examples/topology/libvirt_complete.yml
+++ b/examples/topology/libvirt_complete.yml
@@ -6,19 +6,6 @@
         res_group_type: "libvirt"
         res_defs:
 
-          - res_name: "happy"
-            res_type: "libvirt_storage"
-            size: 100G
-            type: lvm2
-            path: /dev/vms
-
-          - res_name: "sad"
-            res_type: "libvirt_storage"
-            uri: 'qemu:///system'
-            size: 10G
-            type: file
-            path: /var/lib/libvirt/images/linchpin
-
           - res_name: "linchpin-centos72"
             res_type: "libvirt_network"
             ip: 192.168.77.100
@@ -36,9 +23,6 @@
             vcpus: 2
             networks:
               - name: linchpin-centos72
-            storage:
-              - pool: happy
-                size: 10G
 
           - res_name: "centos74"
             res_type: "libvirt_node"
@@ -47,9 +31,3 @@
             vcpus: 1
             networks:
               - name: linchpin-centos74
-                ip: 192.168.78.101
-              - name: linchpin-libvirt
-            storage:
-              - pool: happy
-                size: 10G
-                format: ext4

--- a/linchpin_api/v1/invoke_playbooks.py
+++ b/linchpin_api/v1/invoke_playbooks.py
@@ -51,7 +51,7 @@ def get_evars(pf):
 def invoke_linchpin(base_path, e_vars, playbook="PROVISION", console=True):
     """ Invokes linchpin playbook """
     module_path = base_path+"/library"
-    print("debug:: module path ::"+module_path) 
+    print("debug:: module path ::"+module_path)
     playbook_path = base_path+"/provision/"+PLAYBOOKS[playbook]
     loader = DataLoader()
     variable_manager = VariableManager()
@@ -92,8 +92,8 @@ def invoke_linchpin(base_path, e_vars, playbook="PROVISION", console=True):
                       ssh_extra_args=None,
                       sftp_extra_args=None,
                       scp_extra_args=None,
-                      become=False,
-                      become_method=None,
+                      become=True,
+                      become_method='sudo',
                       become_user='root',
                       verbosity=utils.VERBOSITY,
                       check=False)

--- a/provision/filter_plugins/libvirt_inv.py
+++ b/provision/filter_plugins/libvirt_inv.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+import os
+import sys
+import abc
+import StringIO
+from ansible import errors
+try:
+    from configparser import ConfigParser
+except ImportError:
+    from ConfigParser import ConfigParser
+from InventoryFilters import LibvirtInventory
+
+filepath = os.path.realpath(__file__)
+filepath = "/".join(filepath.split("/")[0:-2])
+sys.path.append(filepath)
+
+
+class FilterModule(object):
+    ''' A filter to fix interface's name format '''
+
+    def filters(self):
+
+        inv = LibvirtInventory.LibvirtInventory()
+        return {
+            'libvirt_inv': inv.get_inventory
+        }

--- a/provision/roles/inventory_gen/tasks/main.yml
+++ b/provision/roles/inventory_gen/tasks/main.yml
@@ -11,6 +11,8 @@
       gcloud_gce_res: "{{ gcloud_gce_res }}"
       duffy_res: "{{ duffy_res }}"
       beaker_res: "{{ beaker_res }}"
+      libvirt_res: "{{ libvirt_res }}"
+  when: state == "present" and inventory_layout is defined
 
 - name: "DEBUG:: inventory_layout"
   debug:

--- a/provision/roles/inventory_gen/templates/libvirt_inventory_formatter.j2
+++ b/provision/roles/inventory_gen/templates/libvirt_inventory_formatter.j2
@@ -1,0 +1,1 @@
+{{ topology_outputs | libvirt_inv(inventory_layout) }}

--- a/provision/roles/libvirt/tasks/copy_image_src.yml
+++ b/provision/roles/libvirt/tasks/copy_image_src.yml
@@ -51,10 +51,6 @@
     img_src_basename: "{{ res_def['image_src'].split('.xz')[0] | basename }}"
   when: lismt.stat.mime_type == "application/x-xz"
 
-- name: "DEBUG: image_src_basename"
-  debug:
-    msg: "image_src_basename {{ image_src_basename }}"
-
 - name: "set img_src for xz compressed files"
   set_fact:
     img_src: "{{ local_image_path }}{{ img_src_basename }}"
@@ -77,7 +73,11 @@
   register: ismt
   when: lismt.stat.mime_type == "application/x-xz"
 
-- name: uncompress xz local_image_src if necessary
+  #- name: "DEBUG: ismt"
+  #  debug:
+  #    var: ismt
+
+- name: uncompress xz local_image_src
   command: "xz -d --keep --force {{ local_image_src }}"
   become: yes
   when: lismt.stat.mime_type == "application/x-xz" and ismt.stat.exists == false
@@ -85,13 +85,15 @@
 - name: "cp img_src to match node name"
   copy:
     src: "{{ img_src }}"
-    dest: "{{ img_item[0] }}{{ img_item[1] }}_{{ img_item[2] }}.{{ img_item[3] }}"
+    dest: "{{ img_item[0] }}{{ img_item[1] }}_{{ img_item[2] }}_{{ img_item[3] }}.{{ img_item[4] }}"
     remote_src: false
   with_nested:
     - ["{{ local_image_path }}"]
+    - ["{{ res_grp_name }}"]
     - ["{{ res_def['res_name'] }}"]
     - "{{ res_count.stdout }}"
     - ["{{ img_src_ext }}"]
   loop_control:
     loop_var: img_item
   become: yes
+  #when: ismt.stat.exists == false (if there's an option at some point to reuse disk, this would be helpful)

--- a/provision/roles/libvirt/tasks/main.yml
+++ b/provision/roles/libvirt/tasks/main.yml
@@ -12,7 +12,7 @@
 
 - name: "declaring output vars"
   set_fact:
-    topology_outputs_libvirt: []
+    topology_outputs_libvirt_nodes: []
 
 - name: "Initiating libvirt resource group"
   include: provision_resource_group.yml res_grp={{ item }}

--- a/provision/roles/libvirt/tasks/provision_libvirt_node.yml
+++ b/provision/roles/libvirt/tasks/provision_libvirt_node.yml
@@ -4,7 +4,7 @@
 
 - name: "does node already exist"
   virt:
-    name: "linchpin_{{ nodeinfo[1]['res_name'] }}_{{ nodeinfo[2] }}"
+    name: "{{ nodeinfo[0] }}_{{ nodeinfo[1]['res_name'] }}_{{ nodeinfo[2] }}"
     command: status
     uri: "{{ nodeinfo[1]['uri'] | default('qemu:///system') }}"
   with_nested:
@@ -15,10 +15,6 @@
   loop_control:
     loop_var: nodeinfo
   register: node_exists
-
-#- name: "DEBUG: node_exists['changed']"
-#  debug:
-#    msg: "{{ node_exists }}"
 
 - name: set empty local_image_path
   set_fact:
@@ -33,11 +29,9 @@
   when: node_exists['failed'] is defined
 
 - name: "define node"
-  virt:
-    name: "linchpin_{{ instance[1]['res_name'] }}_{{ instance[2] }}"
-    command: define
-    xml: "{{ lookup('template', 'libvirt_node.xml.j2') }}"
-    uri: "{{ instance[1]['uri'] | default('qemu:///system') }}"
+  template:
+    src: "../templates/libvirt_node.xml.j2"
+    dest: "/tmp/{{ definition[1]['res_name'] }}_{{ definition[2] }}"
   with_nested:
     - ["{{ res_grp_name }}"]
     - ["{{ res_def }}"]
@@ -45,8 +39,23 @@
     - ["{{ local_image_path }}"]
     - ["{{ img_src_ext }}"]
   loop_control:
-    loop_var: instance
-  register: res_def_output
+    loop_var: definition
+  when:  node_exists['failed'] is defined
+
+- name: "define node"
+  virt:
+    name: "{{ definition[0] }}_{{ definition[1]['res_name'] }}_{{ definition[2] }}"
+    command: define
+    xml: "{{ lookup('template', 'libvirt_node.xml.j2') }}"
+    uri: "{{ definition[1]['uri'] | default('qemu:///system') }}"
+  with_nested:
+    - ["{{ res_grp_name }}"]
+    - ["{{ res_def }}"]
+    - "{{ res_count.stdout }}"
+    - ["{{ local_image_path }}"]
+    - ["{{ img_src_ext }}"]
+  loop_control:
+    loop_var: definition
   when:  node_exists['failed'] is defined
 
 #- name: "map ip and mac addresses in network"
@@ -69,7 +78,7 @@
 
 - name: "start node"
   virt:
-    name: "linchpin_{{ instance[1]['res_name'] }}_{{ instance[2] }}"
+    name: "{{ instance[0] }}_{{ instance[1]['res_name'] }}_{{ instance[2] }}"
     state: running
     uri: "{{ instance[1]['uri'] | default('qemu:///system') }}"
   with_nested:
@@ -80,5 +89,81 @@
     - ["{{ img_src_ext }}"]
   loop_control:
     loop_var: instance
-  register: res_def_output
   when: async == false
+
+
+- name: mac_and_ip | extract mac address
+  shell: >
+    virsh -c {{ node[1]['uri']| default('qemu:///system') }} dumpxml {{ node[0] }}_{{ node[1]['res_name'] }}_{{ node[2] }}
+    | grep 'mac address'
+    | cut -f 2 -d "'"
+  with_nested:
+    - ["{{ res_grp_name }}"]
+    - ["{{ res_def }}"]
+    - "{{ res_count.stdout }}"
+  loop_control:
+    loop_var: node
+  register: extract_mac_address_result
+
+#- name: extract_mac_address_result
+#  debug:
+#    var: extract_mac_address_result.results[0].stdout
+
+- name: mac_and_ip | wait for dhcp ip address
+  shell: |
+    until arp -an | grep -q -F {{ extract_mac_address_result.results[mac].stdout }}; do
+      sleep 1
+    done
+    arp -an | grep -F {{ extract_mac_address_result.results[mac].stdout }} | cut -f 2 -d "(" | cut -f 1 -d ")"
+  with_items:
+    - "{{ res_count.stdout }}"
+  loop_control:
+    loop_var: mac
+  register: extract_ip_address_result
+
+#- name: extract_ip_address_result
+#  debug:
+#    var: extract_ip_address_result.results[{{ ip }}].stdout
+#  with_items:
+#    - "{{ res_count.stdout }}"
+#  loop_control:
+#    loop_var: ip
+
+#- name: set_fact
+#  set_fact:
+#    libvirt_result_ip_addresses: []
+#
+#- name: libvirt_ip | extract facts
+#  set_fact:
+#    libvirt_result_ip_addresses: "{{ extract_ip_address_result.results[ip].stdout }}"
+#  with_items:
+#    - "{{ res_count.stdout }}"
+#  loop_control:
+#    loop_var: ip
+
+- name: "dump node data"
+  virt:
+    name: "{{ data[0] }}_{{ data[1]['res_name'] }}_{{ data[2] }}"
+    command: get_xml
+    uri: "{{ data[1]['uri'] | default('qemu:///system') }}"
+  with_nested:
+    - ["{{ res_grp_name }}"]
+    - ["{{ res_def }}"]
+    - "{{ res_count.stdout }}"
+  loop_control:
+    loop_var: data
+  when: async == false
+  register: node_data
+
+- name: "Append ip_addresses and node_data to topology_outputs_libvirt_nodes"
+  set_fact:
+    topology_outputs_libvirt_nodes: "{{ topology_outputs_libvirt_nodes + [extract_ip_address_result.results[xml_item].stdout] }}"
+  with_items:
+    - "{{ res_count.stdout }}"
+  loop_control:
+    loop_var: xml_item
+  when: async == false
+
+#- name: "Append outputitem to topology_outputs"
+#  set_fact:
+#    topology_outputs_libvirt_node: "{{ topology_outputs_libvirt_node + [res_def_output] }}"

--- a/provision/roles/libvirt/tasks/provision_res_defs.yml
+++ b/provision/roles/libvirt/tasks/provision_res_defs.yml
@@ -10,9 +10,9 @@
   include: provision_libvirt_node.yml
   when: res_def['res_type']=="libvirt_node" and state == "present"
 
-#- name: "teardown libvirt node"
-#  include: teardown_libvirt_node.yml
-#  when: res_def['res_type']=="libvirt_node" and state == "absent"
+- name: "teardown libvirt node"
+  include: teardown_libvirt_node.yml
+  when: res_def['res_type']=="libvirt_node" and state == "absent"
 
 #- name: "teardown libvirt network"
 #  include: teardown_libvirt_network.yml

--- a/provision/roles/libvirt/tasks/teardown_libvirt_node.yml
+++ b/provision/roles/libvirt/tasks/teardown_libvirt_node.yml
@@ -1,0 +1,32 @@
+- name: "register resource count"
+  shell: python -c "print [x for x in range( 0, {{ res_def['count'] | default(1) }} )]"
+  register: res_count
+
+- name: "halt node"
+  virt:
+    name: "{{ instance[0] }}_{{ instance[1]['res_name'] }}_{{ instance[2] }}"
+    state: destroyed
+    uri: "{{ instance[1]['uri'] | default('qemu:///system') }}"
+  with_nested:
+    - ["{{ res_grp_name }}"]
+    - ["{{ res_def }}"]
+    - "{{ res_count.stdout }}"
+  loop_control:
+    loop_var: instance
+  register: res_def_output
+  when: async == false
+
+- name: "undefine node"
+  virt:
+    name: "{{ instance[0] }}_{{ instance[1]['res_name'] }}_{{ instance[2] }}"
+    command: undefine
+    uri: "{{ instance[1]['uri'] | default('qemu:///system') }}"
+  with_nested:
+    - ["{{ res_grp_name }}"]
+    - ["{{ res_def }}"]
+    - "{{ res_count.stdout }}"
+  loop_control:
+    loop_var: instance
+  register: res_def_output
+  when: async == false
+

--- a/provision/roles/libvirt/templates/libvirt_node.xml.j2
+++ b/provision/roles/libvirt/templates/libvirt_node.xml.j2
@@ -1,10 +1,10 @@
-<domain type='{{ instance[1]['driver'] | default('kvm') }}'>
-  <name>linchpin_{{ instance[1]['res_name'] }}_{{ instance[2] }}</name>
-  <memory unit='KiB'>{{ instance[1]['memory'] * 1024 | int }}</memory>
-  <vcpu placement='static'>{{ instance[1]['vcpus'] }}</vcpu>
+<domain type='{{ definition[1]['driver'] | default('kvm') }}'>
+  <name>{{ definition[0] }}_{{ definition[1]['res_name'] }}_{{ definition[2] }}</name>
+  <memory unit='KiB'>{{ definition[1]['memory'] * 1024 | int }}</memory>
+  <vcpu placement='static'>{{ definition[1]['vcpus'] }}</vcpu>
   <os>
-    <type arch='{{ instance[1]['arch'] | default('x86_64') }}'>hvm</type>
-    <boot dev='{{ instance[1]['boot_dev'] | default('hd') }}'/>
+    <type arch='{{ definition[1]['arch'] | default('x86_64') }}'>hvm</type>
+    <boot dev='{{ definition[1]['boot_dev'] | default('hd') }}'/>
   </os>
   <features>
     <acpi/>
@@ -19,17 +19,17 @@
   <on_reboot>restart</on_reboot>
   <on_crash>destroy</on_crash>
   <devices>
-{% if instance[1]['driver'] is defined and instance[1]['driver'] == 'qemu' %}
+{% if definition[1]['driver'] is defined and definition[1]['driver'] == 'qemu' %}
     <emulator>/usr/bin/qemu-system-x86_64</emulator>
 {% else %}
     <emulator>/usr/bin/qemu-kvm</emulator>
 {% endif %}
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2'/>
-      <source file='{{ instance[3] }}{{ instance[1]['res_name'] }}_{{ instance[2] }}.{{ instance[4] }}'/>
+      <source file='{{ definition[3] }}{{ definition[0] }}_{{ definition[1]['res_name'] }}_{{ definition[2] }}.{{ definition[4] }}'/>
       <target dev='vda' bus='virtio'/>
     </disk>
-{% for network in instance[1]['networks'] %}
+{% for network in definition[1]['networks'] %}
     <interface type='network'>
       <model type='virtio'/>
       <source network='{{ network['name'] }}'/>

--- a/provision/roles/openstack/tasks/main.yml
+++ b/provision/roles/openstack/tasks/main.yml
@@ -14,7 +14,7 @@
     topology_outputs_os_sg: []
 
 - name: "Initiating  Provisioning/Deprovioning of resources Openstack resource group"
-  include: provision_resource_group.yml res_grp={{ item }} 
+  include: provision_resource_group.yml res_grp={{ item }}
   with_items:
     - "{{ os_res_grps }}"
   register: resource_grps_output

--- a/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/provision/roles/openstack/tasks/provision_os_server.yml
@@ -44,7 +44,7 @@
   register: res_def_output
   when: async == true
 
-# following tasks saves the async job details 
+# following tasks saves the async job details
 - name: "Async:: save the job id"
   set_fact:
     topology_outputs_os_server: "{{ topology_outputs_os_server + [ res_def_output ] }}"

--- a/provision/roles/openstack/tasks/provision_resource_group.yml
+++ b/provision/roles/openstack/tasks/provision_resource_group.yml
@@ -4,7 +4,7 @@
 
 - name: "Including credentials of current resource {{ res_grp['resource_group_name'] }} "
   include_vars: "roles/openstack/vars/{{ res_grp['assoc_creds'] }}.yml"
-  no_log: false 
+  no_log: false
 
 - name: "provisioning resource definitions of current group"
   include: provision_res_defs.yml res_def={{ res_item.0 }} res_grp_name={{ res_item.1 }}

--- a/provision/roles/output_writer/tasks/main.yml
+++ b/provision/roles/output_writer/tasks/main.yml
@@ -19,6 +19,7 @@
       duffy_res: "{{ topology_outputs_duffy  | default([]) }}"
       rax_server_res: "{{ topology_outputs_rax_server  | default([]) }}"
       beaker_res: "{{ topology_outputs_beaker_server | default([]) }}"
+      libvirt_res: "{{ topology_outputs_libvirt_nodes | default([]) }}"
   when: async == false
 
 - name: "Create output directories"
@@ -64,6 +65,7 @@
       duffy_res: "{{ topology_outputs_duffy | default([]) }}"
       rax_server_res: "{{ topology_outputs_rax_server | default([]) }}"
       beaker_res: "{{ topology_outputs_beaker_server | default([]) }}"
+      libvirt_res: "{{ topology_outputs_libvirt_nodes | default([]) }}"
   when: async == true
 
 # currently adding a single playbook that can manage all the async outputs based on the resource groups
@@ -89,6 +91,7 @@
       duffy_res: "{{ topology_outputs_duffy | default([]) }}"
       rax_server_res: "{{ topology_outputs_rax_server | default([]) }}"
       beaker_res: "{{ topology_outputs_beaker_server | default([]) }}"
+      libvirt_res: "{{ topology_outputs_libvirt_nodes | default([]) }}"
   when: async == true
 
 # pretty much the same output generation when async_false

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ click
 tabulate
 beaker-client==23.3
 sphinx_rtd_theme
+libvirt-python>=3.0.0


### PR DESCRIPTION
This PR fixes #98 and #154, as described below:

* Reworked libvirt provisioning 
  * Renamed libvirt_nodes to reflect resource_group res_name and count, separated by an underscore
  * Determine IP addresses of nodes for output and inventory generation
  * Add teardown_node functionality (it works!!!)
  * Copying source image name reflects libvirt_node name
* Added libvirt-python to requirements.txt
* Update filter_plugins to allow for Libvirt  
 * Added libvirt_inv filter_plugin
 * Added LibvirtInventory class to generate a proper inventory for libvirt topologies
  * Added LibvirtInventory to GenericInventory and InventoryProviders
* Updated libvirt_complete.yml example
  * remove libvirt_storage usage (moved to v1.1.0)
  * remove multiple network definitions (only one allowed at this time)
  * textual cleanup on openstack module
* Because copying source images into /var/lib/libvirt/images requires privileges, adjustments to become inside invoke_linchpin.py have been made. However, this should become more flexible with #155.
* Proper output and inventory generation for libvirt