### PR TITLE
Fixup contributing link to point to develop

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Contributing
 ++++++++++++
 
 Developers are encouraged to contribute to the Linch-Pin project. Please visit
-`Contributing <http://github.com/CentOS-PaaS-SIG/linch-pin/tree/master/CONTRIBUTING.rst>`_
+`Contributing <http://github.com/CentOS-PaaS-SIG/linch-pin/tree/develop/CONTRIBUTING.rst>`_
 for details.
 
 Installation


### PR DESCRIPTION
The link to CONTRIBUTING.rst was pointing to master. However, master is intended to be stable only. Since the github front page points to develop branch, it makes sense to update this link in this way. It also requires a Pull Request to merge from develop to master. I believe the process to merge from develop to master should be much more controlled. Thus, this simple PR will fixup the needed link.