### PR TITLE
Hot fixes : linchpin_config resolution , aws_ec2 default instance tags #167

### DIFF
--- a/provision/roles/aws/tasks/provision_aws_ec2.yml
+++ b/provision/roles/aws/tasks/provision_aws_ec2.yml
@@ -1,3 +1,11 @@
+- name: "Set default res_grp_vars when not defined"
+  set_fact:
+    res_grp_vars:
+      -       
+        name: "{{ res_def['res_name'] | default(res_def['name']) }}"
+        resource_group_name: "{{ res_grp_name  }}"
+  when: res_grp_vars is not defined
+
 - name: "Provisioning AWS_EC2 Resource when async == false"
   ec2:
     aws_access_key: "{{ aws_access_key_id | default(omit) }}"
@@ -32,7 +40,7 @@
     group: "{{ res_def['security_group']| default('default') }}"
     count: "{{ res_def['count'] }}"
     vpc_subnet_id: "{{ res_def['vpc_subnet_id']| default(omit) }}"
-    assign_public_ip: "{{ res_def['assign_public_ip']| default(omit) }}"
+    assign_public_ip: "{{ res_def['assign_public_ip'] | default(omit) }}"
     instance_tags: "{{ res_grp_vars | selectattr('resource_group_name', 'equalto', res_grp_name ) | first }}"
   async: "{{ async_timeout }}"
   poll: 0

--- a/provision/site.yml
+++ b/provision/site.yml
@@ -8,7 +8,7 @@
     - name: "Include linchpin_config"
       include_vars: "{{ item }}"
       with_first_found:
-        - "{{ linchpin_config.yml | default(omit) }}"
+        - "{{ linchpin_config | default(omit) }}"
         - "../linchpin_config.yml"
         - "~/.linchpin_config.yml"
         - "/usr/linchpin_config.yml"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def list_all_files(root_dir):
 
 setup(
     name='linchpin',
-    version='0.8.6',
+    version='0.9.1',
     description = 'Ansible based multi cloud orchestrator',
     author = 'samvaran kashyap rallabandi',
     author_email = 'samvaran.kashyap@gmail.com',


### PR DESCRIPTION
Summary :
-   While initiating provisioning , it is observed that linchpin cli passes path of linchpin_config.yaml
file in linchpin_config extra var. However , its not being used while resolving the linchpin config file
due to a typo. This current commit resolves the config resolution issue of linchpin.
-   Currently , Provisioning of aws_ec2 instances are failing when res_grp_vars in undefined due to the  fact res_grp_vars are being used as instance tags while provisioning ec2 instance. In the current commit fixes the bug by setting resource_group_name and res_name as  default values of res_grp_vars for any instance when the res_grp_vars are undefined in topology.
- Resolves : issue #167
