### PR TITLE
Only register openstack provision outputs once

### DIFF
--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -38,7 +38,6 @@
     nics:  "{{ res_def['networks'] | os_net }}"
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
-  register: res_def_output
   async: "{{ async_timeout | default(1000) }}"
   poll: 0
   register: res_def_output


### PR DESCRIPTION
Having the "register:" declaration in there twice was causing ansible to
throw a warning on this task.