### PR TITLE
Declare babel package with a minimum version.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 setuptools>=17.1
 oslo.config<3.23.0
+Babel!=2.4.0,>=2.3.4
 oslo.i18n<3.13.0
 oslo.serialization<2.17.0
 oslo.utils<3.23.0


### PR DESCRIPTION
Running into issues when installing linchpin. Seems one of its packages it depends on needs a version of babel not equal too 2.4.0. Switching to a minimum version of 2.3.4 allows the install to work.