### PR TITLE
Enhancements for Python compatibility

### DIFF
--- a/linchpin/__init__.py
+++ b/linchpin/__init__.py
@@ -5,7 +5,6 @@ import sys
 import click
 import shutil
 import logging
-import ConfigParser
 
 from distutils import dir_util
 from jinja2 import Environment, PackageLoader

--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -64,7 +64,7 @@ class LinchpinAPI:
                 topology_registry = pf.get("topology_registry", None)
                 self.ctx.evars['topology'] = self.find_topology(pf[target]["topology"],
                                                         topology_registry)
-                if pf[target].has_key("layout"):
+                if 'layout' in pf[target]:
                     self.ctx.evars['layout_file'] = (
                         '{0}/{1}/{2}'.format(self.ctx.workspace,
                                     self.ctx.cfgs['evars']['layouts_folder'],
@@ -87,7 +87,7 @@ class LinchpinAPI:
                 topology_registry = pf.get("topology_registry", None)
                 self.ctx.evars['topology'] = self.find_topology(pf[target]["topology"],
                                                         topology_registry)
-                if pf[target].has_key("layout"):
+                if 'layout' in pf[target]:
                     self.ctx.evars['layout_file'] = (
                         '{0}/{1}/{2}'.format(self.ctx.workspace,
                                     self.ctx.cfgs['evars']['layouts_folder'],

--- a/linchpin/api/invoke_playbooks.py
+++ b/linchpin/api/invoke_playbooks.py
@@ -9,7 +9,7 @@ from ansible.parsing.dataloader import DataLoader
 from ansible.vars import VariableManager
 from ansible.inventory import Inventory
 from ansible.executor.playbook_executor import PlaybookExecutor
-from callbacks import PlaybookCallback
+from linchpin.api.callbacks import PlaybookCallback
 
 from collections import namedtuple
 

--- a/linchpin/context.py
+++ b/linchpin/context.py
@@ -5,8 +5,11 @@ import sys
 import click
 import shutil
 import logging
-import ConfigParser
 
+try:
+    import configparser as ConfigParser
+except ImportError:
+    import ConfigParser as ConfigParser
 from distutils import dir_util
 from jinja2 import Environment, PackageLoader
 
@@ -83,7 +86,7 @@ class LinchpinContext(object):
                     ' {0}'.format(e))
 
         for section in config.sections():
-            if not self.cfgs.has_key(section):
+            if section not in self.cfgs:
                 self.cfgs[section] = {}
 
             # add evars to the ansible extra_vars when running a playbook.

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 from pip.req import parse_requirements
 import os
 
-with file('linchpin/version.py') as f:
+with open('linchpin/version.py') as f:
     for line in f:
         if line.startswith('__version__'):
             ver = ast.parse(line).body[0].value.s


### PR DESCRIPTION
This commit improves linch-pins compatibility with Python 2 and Python 3. Changes consist of fixing import statements, checking if dictionary objects have attributes and using built in functions. More details can be found in each commit.