### PR TITLE
Develop :: Added support for security_groups parameter in os_server resource 

### DIFF
--- a/linchpin/defaults/schemas/schema_v2.json
+++ b/linchpin/defaults/schemas/schema_v2.json
@@ -87,6 +87,9 @@
                 },
                 "keypair": {
                   "type":"string"
+                },
+		"security_groups": {
+                  "type":"string"
                 }
               },
              "required":["flavor","res_type","image","count","keypair"]

--- a/linchpin/defaults/schemas/schema_v3.json
+++ b/linchpin/defaults/schemas/schema_v3.json
@@ -62,7 +62,10 @@
                 },
 		"fip_pool": {
 		    "type":"string"
-		}
+		},
+		"security_groups": {
+                    "type":"string"
+                }
             },
             "required":["flavor","res_type","image","count","keypair"]
         },

--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -52,7 +52,10 @@
                 },
 		"fip_pool": {
 		    "type":"string"
-		}
+		},
+		"security_groups": {
+                    "type":"string"
+                }
             },
             "required":["flavor","type","image","count","keypair"]
         },

--- a/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
+++ b/linchpin/provision/roles/openstack/tasks/provision_os_server.yml
@@ -13,6 +13,7 @@
     flavor: "{{ res_def['flavor'] }}"
     nics:  "{{ res_def['networks'] | os_net }}"
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
+    security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
   when: not async
   register: res_def_output
@@ -37,6 +38,7 @@
     flavor: "{{ res_def['flavor'] }}"
     nics:  "{{ res_def['networks'] | os_net }}"
     floating_ip_pools: "{{ res_def['fip_pool'] | default(omit) }}"
+    security_groups: "{{ res_def['security_groups'] | default(omit) }}"
     count: "{{ res_def['count'] }}"
   async: "{{ async_timeout | default(1000) }}"
   poll: 0


### PR DESCRIPTION
Surprisingly , though linchpin can create security groups on openstack , it cannot assign security groups to the provisioned instances. 
Current pr resolves this issue by adding security_groups parameter to os_server resource which accepts comma separated values of security groups in topology. 