### PR TITLE
Give the full path for importing PlaybookCallback.

### DIFF
--- a/linchpin/api/__init__.py
+++ b/linchpin/api/__init__.py
@@ -3,7 +3,7 @@
 import os
 from collections import namedtuple
 
-from callbacks import PlaybookCallback
+from linchpin.api.callbacks import PlaybookCallback
 from ansible.inventory import Inventory
 from ansible.vars import VariableManager
 from ansible.parsing.dataloader import DataLoader


### PR DESCRIPTION
A module not found error is being raised when installing linch-pin using Python3.
Setting the full path allows linch-pin install on Python2 & Python3 to be successful.