### PR TITLE
Add failed results to callbacks.py

### DIFF
--- a/linchpin/api/callbacks.py
+++ b/linchpin/api/callbacks.py
@@ -14,6 +14,12 @@ class PlaybookCallback(CallbackBase):
 
     def v2_runner_on_ok(self, result, **kwargs):
 
-        """Save result instead of printing it"""
+        """Save ok result"""
+
+        self.results.append(result)
+
+    def v2_runner_on_failed(self, result, **kwargs):
+
+        """Save failed result"""
 
         self.results.append(result)

--- a/linchpin/api/callbacks.py
+++ b/linchpin/api/callbacks.py
@@ -12,7 +12,7 @@ class PlaybookCallback(CallbackBase):
         self.results = []
 
 
-    def v2_runner_on_ok(self, result, **kwargs):
+    def v2_runner_on_ok(self, result):
 
         """Save ok result"""
 

--- a/linchpin/cli/context.py
+++ b/linchpin/cli/context.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import ast
 import shutil
 import logging
 
@@ -123,7 +124,7 @@ class LinchpinContext(object):
 
         """
 
-        self.enable_logging = eval(self.cfgs['logger'].get('enable', 'True'))
+        self.enable_logging = ast.literal_eval(self.cfgs['logger'].get('enable', 'True'))
 
         if self.enable_logging:
 


### PR DESCRIPTION
Addresses API calls which do not use the console, The callback now
stores failed results so they can be returned.