### PR TITLE
whiteboard + hostrequires beaker support, with docs and examples updates

### DIFF
--- a/docs/source/topologies_beaker.rst
+++ b/docs/source/topologies_beaker.rst
@@ -17,6 +17,7 @@ Beaker Server
       - resource_group_name: test1
         res_group_type: beaker
         job_group: ci-ops-central
+        whiteboard: Arbitrary Job whiteboard string
         recipesets:
           - distro: RHEL-6.5
             arch: x86_64

--- a/docs/source/topologies_beaker.rst
+++ b/docs/source/topologies_beaker.rst
@@ -7,7 +7,7 @@ Beaker Topologies
 
 
 Beaker Server
-```````````````
+`````````````
 
 .. code-block:: yaml
 
@@ -21,9 +21,6 @@ Beaker Server
         recipesets:
           - distro: RHEL-6.5
             arch: x86_64
-            arches:
-              - X86_64
-              - X86_64
             keyvalue:
               - MEMORY>1000
               - DISKSPACE>20000
@@ -51,7 +48,7 @@ The reservation of a specific hostname can be done with the ``force`` keyword ne
 recipeset's ``hostrequires`` mapping. Additional filtering,
 such as a ``keyvalue`` or ``hostrequires`` filter, is silently ignored by beaker when the hostname
 to reserve is forced. Because of this, using the ``force`` argument is mutually exclusive to using
-and other filters.
+any other filters.
 
 For example::
 

--- a/docs/source/topologies_beaker.rst
+++ b/docs/source/topologies_beaker.rst
@@ -27,10 +27,50 @@ Beaker Server
             keyvalue:
               - MEMORY>1000
               - DISKSPACE>20000
-            hostrequire:
-              - arch=X86_64
+            hostrequires:
+              - tag: processors
+                op: ">="
+                value: 4
+              - tag: device
+                op: "="
+                type: "network"
             count: 1
 
 .. note::
 
   Source of the above Beaker example can be found at `Example Topologies <https://github.com/CentOS-PaaS-SIG/linch-pin/tree/master/examples/topology>`_
+
+Requiring Specific Hosts
+````````````````````````
+
+By default, any host available to the named ``job_group`` can be selected for use in a given job.
+If a specific host, or hosts, is desired, ``hostrequires`` filters can be used to refine the hosts
+selected for use in a given job.
+
+The reservation of a specific hostname can be done with the ``force`` keyword nested within a
+recipeset's ``hostrequires`` mapping. Additional filtering,
+such as a ``keyvalue`` or ``hostrequires`` filter, is silently ignored by beaker when the hostname
+to reserve is forced. Because of this, using the ``force`` argument is mutually exclusive to using
+and other filters.
+
+For example::
+
+    hostrequires:
+      - force: beaker.machine.hostname
+
+Beaker supports globbing via the "like" operator::
+
+    hostrequires:
+      - tag: hostname
+        op: like
+        value: beaker-%.machine.hostname
+
+This glob will match hostnames like ``beaker-01.machine.hostname``, allowing you to select from
+a subset of machines available in the given job group. This acts like any other "hostrequires"
+filter, so it can be combined with those filters to futher ensure that only nodes with required
+cababilities are selected for a job (unlike when ``force`` is used).
+
+.. note::
+
+    The "op" keyword of a hostrequires filter should be quoted when the operator contains symbols,
+    such as "==", "!=", or ">=".

--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -90,6 +90,9 @@
                  "job_group": {
                      "type": "string"
                  },
+                 "whiteboard": {
+                     "type": "string"
+                 },
                  "recipesets": {
                      "type": "array",
                      "items": {

--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -102,9 +102,6 @@
                                  "distro": {
                                      "type": "string"
                                  },
-                                 "arches": {
-                                     "type": "array"
-                                 },
                                  "arch": {
                                      "type": "string"
                                  },

--- a/linchpin/defaults/schemas/schema_v4.json
+++ b/linchpin/defaults/schemas/schema_v4.json
@@ -114,8 +114,30 @@
                                  "keyvalue": {
                                      "type": "array"
                                  },
-                                 "hostrequire": {
-                                     "type": "array"
+                                 "hostrequires": {
+                                     "type": "array",
+                                     "items": {
+                                         "oneOf": [
+                                             {
+                                                 "type": "object",
+                                                 "properties": {
+                                                     "force": {
+                                                         "type": "string"
+                                                     }
+                                                 },
+                                                 "required": ["force"]
+                                             },
+                                             {
+                                                 "type": "object",
+                                                 "properties": {
+                                                     "tag": {
+                                                         "type": "string"
+                                                     }
+                                                 },
+                                                 "required": ["tag"]
+                                             }
+                                          ]
+                                     }
                                  },
                                  "bkr_data": {
                                     "type": "object"

--- a/linchpin/examples/topologies/beaker_fedoraproject_server.yml
+++ b/linchpin/examples/topologies/beaker_fedoraproject_server.yml
@@ -11,6 +11,4 @@ resource_groups:
         keyvalue:
           - MEMORY>1000
           - DISKSPACE>20000
-        hostrequire:
-          - arch=X86_64
         count: 1

--- a/linchpin/examples/topologies/beaker_fedoraproject_server.yml
+++ b/linchpin/examples/topologies/beaker_fedoraproject_server.yml
@@ -6,8 +6,6 @@ resource_groups:
     recipesets:
       - distro: Fedora-24
         arch: x86_64
-        arches:
-          - X86_64
         keyvalue:
           - MEMORY>1000
           - DISKSPACE>20000

--- a/linchpin/examples/topologies/beaker_server.yml
+++ b/linchpin/examples/topologies/beaker_server.yml
@@ -4,6 +4,7 @@ resource_groups:
   - resource_group_name: test1
     res_group_type: beaker
     job_group: ci-ops-central
+    whiteboard: Arbitrary Job whiteboard string
     recipesets:
       - distro: RHEL-6.5
         arch: x86_64

--- a/linchpin/examples/topologies/beaker_server.yml
+++ b/linchpin/examples/topologies/beaker_server.yml
@@ -14,6 +14,11 @@ resource_groups:
         keyvalue:
           - MEMORY>1000
           - DISKSPACE>20000
-        hostrequire:
-          - arch=X86_64
+        hostrequires:
+          - tag: processors
+            op: ">="
+            value: 4
+          - tag: device
+            op: "="
+            type: "network"
         count: 1

--- a/linchpin/examples/topologies/beaker_server.yml
+++ b/linchpin/examples/topologies/beaker_server.yml
@@ -8,9 +8,6 @@ resource_groups:
     recipesets:
       - distro: RHEL-6.5
         arch: x86_64
-        arches:
-          - X86_64
-          - X86_64
         keyvalue:
           - MEMORY>1000
           - DISKSPACE>20000

--- a/linchpin/provision/library/bkr_server.py
+++ b/linchpin/provision/library/bkr_server.py
@@ -66,6 +66,7 @@ class BkrFactory(BkrConn):
             ks_meta = kwargs.get("ks_meta", "")
             method = kwargs.get("method", "nfs")
             priority = kwargs.get("priority", "Normal")
+            hostrequires = kwargs.get("hostrequires", [])
 
             # Tasks and harnesses
             if 'harness' in ks_meta:
@@ -111,6 +112,27 @@ class BkrFactory(BkrConn):
 
             # Create Base Recipe
             recipe_template = BeakerRecipe(*args, **kwargs)
+
+            # Add Host Requirements
+            if 'force' in hostrequires:
+                # hostRequires element is created by BeakerRecipe, use it
+                hostrequires_node = recipe_template.node.getElementsByTagName('hostRequires')[0]
+                # all other filters are ignored if the hostname is forced, so the use of 'force'
+                # is mutually exclusive with the use of any other 'hostRequires' filters
+                hostrequires_node.setAttribute('force', hostrequires['force'])
+            else:
+                for requirement in hostrequires:
+                    # If force is not used, a requirement can be any number of differently
+                    # formatted XML elements, each with their own combination of element name and
+                    # valid attrs. So, the best we can do is generate XML based on the input, and
+                    # only the "tag" key is required.
+                    tag_name = requirement.pop('tag')
+                    requirement_node = self.doc.createElement(tag_name)
+                    for attr, value in requirement.items():
+                        # Force all values to str, which the XML writer expects.
+                        requirement_node.setAttribute(attr, str(value))
+                    # use the BeakerRecipe API to add the element
+                    recipe_template.addHostRequires(requirement_node)
 
             # Add Distro Requirements
             recipe_template.addBaseRequires(*args, **kwargs)

--- a/linchpin/provision/library/bkr_server.py
+++ b/linchpin/provision/library/bkr_server.py
@@ -47,7 +47,7 @@ class BkrFactory(BkrConn):
         """
             provision resources in Beaker
         """
-        # Break down kwargs for debug, dryrun, wait, and recipesets
+        # Break down kwargs for debug, dryrun, wait, recipesets, and whiteboard
         debug = kwargs.get("debug", False)
         dryrun = kwargs.get("dryrun", False)
         wait = kwargs.get("wait", False)
@@ -215,6 +215,7 @@ class BkrFactory(BkrConn):
 
 def main():
     module = AnsibleModule(argument_spec={
+        'whiteboard': {'required': False, 'type': 'str'},
         'recipesets': {'required': True, 'type': 'list'},
         'job_group': {'required': True, 'type': 'str'},
         'state': {'default': 'present', 'choices': ['present', 'absent']},
@@ -230,7 +231,8 @@ def main():
                 # Make provision
                 job_id = factory.provision(debug=True, wait=True,\
                                            recipesets=[recipeset],\
-                                           job_group=params.job_group)
+                                           job_group=params.job_group,
+                                           whiteboard=params.whiteboard)
                 job_ids.extend(job_id)
             else:
                 factory.cancel_jobs(recipeset['ids'], params.cancel_message)

--- a/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
+++ b/linchpin/provision/roles/beaker/tasks/provision_resource_group.yml
@@ -2,6 +2,7 @@
 
 - name: "provision beaker systems"
   bkr_server:
+    whiteboard: "{{ res.whiteboard | default('Provisioned with linchpin') }}"
     recipesets: "{{ res.recipesets }}"
     state: present
     job_group: "{{ res.job_group }}"


### PR DESCRIPTION
This PR adds support for the beaker job whiteboard to beaker topologies, and improves support for the beaker API's `hostRequires` filtering. Docs related to the hostrequires configuration have been added, and I've also updated the beaker examples.

closes #182
closes #196 